### PR TITLE
Improve perf

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -11,11 +11,11 @@
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/http": "2.0.0 <= v < 3.0.0",
-        "ianmackenzie/elm-geometry": "3.0.0 <= v < 4.0.0",
-        "ianmackenzie/elm-triangular-mesh": "1.0.4 <= v < 2.0.0",
-        "ianmackenzie/elm-units": "2.2.0 <= v < 3.0.0"
+        "ianmackenzie/elm-geometry": "3.9.0 <= v < 4.0.0",
+        "ianmackenzie/elm-triangular-mesh": "1.1.0 <= v < 2.0.0",
+        "ianmackenzie/elm-units": "2.7.0 <= v < 3.0.0"
     },
     "test-dependencies": {
-        "elm-explorations/test": "1.0.0 <= v < 2.0.0"
+        "elm-explorations/test": "1.2.2 <= v < 2.0.0"
     }
 }


### PR DESCRIPTION
Reordered case expressions and removed `String.startsWith`.  When compared to decoding mesh from JSON:

Before:


<img width="510" alt="Screenshot 2021-01-25 at 22 09 13" src="https://user-images.githubusercontent.com/43472/105766429-09244780-5f5a-11eb-933f-3c3c5aa8d3bf.png">


After:

<img width="514" alt="Screenshot 2021-01-25 at 22 04 46" src="https://user-images.githubusercontent.com/43472/105766453-0de8fb80-5f5a-11eb-8eba-931f67551062.png">

