### PR TITLE
Specialize parsing of blocks of the same elements

### DIFF
--- a/benchmarks/src/SlowDecodeBenchmark.elm
+++ b/benchmarks/src/SlowDecodeBenchmark.elm
@@ -1,4 +1,4 @@
-module DecodeBenchmark exposing (main)
+module SlowDecodeBenchmark exposing (main)
 
 import Benchmark
 import Benchmark.Runner exposing (BenchmarkProgram, program)


### PR DESCRIPTION
Having read the "Use specialization" section of https://romgrk.com/posts/optimizing-javascript#9-use-specialization I got another idea for performance optimization.

Oftentimes, the lines that define vertices, normals, uvs and faces are grouped. This means that if the parser encounters a line that defines a vertex (starting with `v`), it could switch into the mode of parsing only vertices until it sees something else. In this mode, each next line only needs to be checked if it starts with `v`, instead of being considered for any other possibility.

This made the parser 24% faster in Safari 

<img width="599" alt="safari" src="https://github.com/w0rm/elm-obj-file/assets/43472/7bcb0c95-01a7-4fcf-8058-b4aea5cd5909">


And 6% faster in Chrome

<img width="572" alt="chrome" src="https://github.com/w0rm/elm-obj-file/assets/43472/ba9252f2-af45-42e5-8622-c263d128dd74">


